### PR TITLE
Revert use of alpine linux for docker container

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM node:6.9.4-alpine
+FROM flywheelsports/servicebase:0.0.2
 MAINTAINER Carlos Justiniano cjus34@gmail.com
 EXPOSE 80 
 RUN mkdir -p /usr/src/app


### PR DESCRIPTION
because it can't be used with uws. This is due to uws dependencies on native libraries.